### PR TITLE
fix chapitres extras, styles & meilleure responsivité mobile

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+
+    <head>
+        <style>
+            :root {
+                --bg: #15171a;
+                --text: #ffffff;
+                --accent: #0095AD;
+            }
+
+            html {
+                scroll-behavior: smooth;
+            }
+
+            * {
+                box-sizing: border-box;
+            }
+
+            body {
+                margin: 0;
+                padding: .5rem;
+                background-color: var(--bg);
+                color: var(--text);
+                font-size: 18px;
+                display: flex;
+                justify-content: center;
+                flex-direction: column;
+                align-items: center;
+                min-height: 100vh;
+                min-height: 100dvh;
+                font-family: "Urbanist", system-ui, sans-serif;
+                text-align: center;
+            }
+
+            h1 {
+                margin: 0;
+            }
+
+            img {
+                height: 1em;
+                vertical-align: text-top;
+            }
+
+            a {
+                background: var(--accent);
+                color: var(--text);
+                text-decoration: none;
+                padding: .7rem 1.5rem;
+                border-radius: 8px;
+                font-weight: 600;
+                transition: opacity 0.3s ease, box-shadow 0.3s ease;
+            }
+
+            a:hover {
+                opacity: 0.8;
+                box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+            }
+        </style>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta http-equiv="refresh" content="5; url=/">
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link href="https://fonts.googleapis.com/css2?family=Urbanist:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet" />
+        <link rel="icon" type="image/png" href="/img/icon.png" />
+        <title>Erreur 404 - BigSolo</title>
+    </head>
+
+    <body>
+        <h1>Erreur 404 <img src="/img/emojis/shrug.png" alt=""></h1>
+        <p>La page que vous recherchez n'est pas ou plus disponible. Vous allez être redirigé vers la page d'accueil dans <span id="sec">5</span> secondes.</p>
+        <a href="/">Si vous n'êtes pas redirigé, appuyez ici.</a>
+    </body>
+
+</html>

--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,5 @@
+# redirection legacy
+/series-detail/* /:splat
+
+# rediriger les url /episode vers /episodes
+/:series/episode/:episode /:series/episodes/:episode

--- a/css/components/accordion.css
+++ b/css/components/accordion.css
@@ -191,4 +191,8 @@ body.dark .detail-chapter-item {
     .detail-chapter-date {
       font-size: .75rem;
     }
+
+    .detail-chapter-date {
+      margin-left: auto;
+    }
 }

--- a/css/components/accordion.css
+++ b/css/components/accordion.css
@@ -42,15 +42,15 @@ body.dark .volume-header {
   flex-shrink: 0;
 }
 
-.volume-license-details {
-  display: flex;
-  align-items: center;
-  flex-grow: 1;
-  font-size: 0.9em;
+.volume-release-date {
   color: var(--clr-text-sub);
-  gap: 0.5em;
-  margin-left: 1em;
-  white-space: nowrap;
+  font-weight: 600;
+}
+
+.volume-license-text {
+  font-size: 0.9em;
+  font-weight: 600;
+  color: var(--clr-text-sub);
   overflow: hidden;
   text-overflow: ellipsis;
 }
@@ -83,35 +83,19 @@ body.dark .volume-header {
   max-height: 0;
   overflow: hidden;
   transition: max-height 0.4s ease-out;
-  padding: 0 1rem;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
-}
-
-.volume-chapters-list .detail-chapter-item:first-child {
-  padding-top: 1rem;
-}
-
-.volume-chapters-list .detail-chapter-item:last-child {
-  border-bottom: none;
-  padding-bottom: 1rem;
 }
 
 .detail-chapter-item {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0.7rem 1rem;
+  padding: 1rem;
   cursor: pointer;
   transition: background 0.2s ease, transform 0.2s ease;
-  border-bottom: 1px solid rgba(var(--clr-text-rgb), 0.08);
+  border-bottom: 1px solid rgba(var(--clr-text-rgb), 0.05);
   text-decoration: none;
-}
-
-.volume-chapters-list .detail-chapter-item {
-  padding: 0.7rem 0;
-  border-bottom-color: rgba(var(--clr-text-rgb), 0.05);
 }
 
 body.dark .detail-chapter-item {
@@ -124,8 +108,16 @@ body.dark .detail-chapter-item {
   opacity: 0.7;
 }
 
+.detail-chapter-item.licensed-chapter-item .detail-chapter-likes[data-like-count="0"],
+.detail-chapter-item.licensed-chapter-item .detail-chapter-comments[data-comment-count="0"] {
+  display: none;
+}
+
 .detail-chapter-item:hover:not(.licensed-chapter-item) {
   background: rgba(var(--clr-primary-rgb), 0.08);
+}
+
+.detail-chapter-item:hover:not(.licensed-chapter-item) .chapter-main-info {
   transform: translateX(5px);
 }
 
@@ -178,22 +170,21 @@ body.dark .detail-chapter-item {
 /* --- Media Queries --- */
 @media (max-width: 768px) {
     .volume-header {
-      padding: .7rem 1rem;
+      padding: .7rem .8rem;
       font-size: 1rem;
     }
   
-    .volume-license-details {
+    .volume-license-text {
       font-size: .8em;
-      margin-left: .5em;
-    }
-  
-    .volume-chapters-list {
-      padding: 0 .7rem;
+      display: block;
     }
   
     .volume-chapters-list .detail-chapter-item {
-      padding: .6rem 0;
+      padding: .6rem;
+      padding-left: .8rem;
       font-size: .8rem;
+      flex-direction: column;
+      align-items: flex-start;
     }
   
     .detail-chapter-collab,

--- a/css/components/reader.css
+++ b/css/components/reader.css
@@ -57,10 +57,10 @@ body:has(.reader-controls-sidebar.open) {
 
 .reader-viewer-container {
   background-color: #e9ecef;
-  min-height: calc(100vh - 60px);
+  min-height: calc(100vh - 70px - 22px);
   -webkit-user-select: none;
   user-select: none;
-  height: calc(100vh - 60px);
+  height: calc(100vh - 70px - 22px);
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
 }
@@ -80,7 +80,7 @@ body.dark .reader-viewer-container {
   justify-content: center;
   align-items: center;
   min-height: 100%;
-  padding: 1.5rem;
+  padding: .5rem;
   box-sizing: border-box;
 }
 .reader-viewer img {
@@ -134,7 +134,7 @@ body.dark .reader-viewer-container {
   object-fit: contain;
 }
 .reader-viewer.fit-height img {
-  max-height: calc(100vh - 60px - 3rem);
+  max-height: calc(100vh - 70px - 22px - 1rem);
   width: auto;
 }
 .reader-viewer.fit-width img {
@@ -143,7 +143,7 @@ body.dark .reader-viewer-container {
 }
 .reader-viewer.fit-both img {
   max-width: 100%;
-  max-height: calc(100vh - 60px - 3rem);
+  max-height: calc(100vh - 70px - 22px - 1rem);
   object-fit: contain;
 }
 .reader-viewer.fit-original img {
@@ -204,6 +204,7 @@ body.dark .reader-viewer-container {
   padding-bottom: 1rem;
   margin-bottom: 0.5rem;
   flex-shrink: 0;
+  border-bottom: 1px solid var(--clr-primary);
 }
 .reader-stats-box {
   display: flex;

--- a/css/pages/homepage.css
+++ b/css/pages/homepage.css
@@ -345,10 +345,6 @@
     backdrop-filter: none;
   }
 
-  .hero-info-top {
-    /* Conteneur pour le titre et les tags */
-  }
-
   .hero-info .recommended-title,
   .hero-info .hero-description,
   .hero-info .hero-latest-info {
@@ -358,7 +354,7 @@
   .hero-info .hero-series-title {
     font-size: 2.2rem;
     margin-bottom: 0.8rem;
-    text-shadow: 1px 1px 5px rgba(0, 0, 0, 0.5); /* On peut remettre une ombre légère si besoin */
+    text-shadow: 1px 1px 5px rgba(0, 0, 0, 0.2); /* On peut remettre une ombre légère si besoin */
   }
 
   .hero-info .hero-tags {

--- a/css/pages/series-detail.css
+++ b/css/pages/series-detail.css
@@ -175,7 +175,7 @@ p.detail-description {
   background-color: transparent;
   color: var(--clr-text-sub);
   cursor: pointer;
-  border-bottom: 3px solid transparent;
+  border-bottom: 2px solid transparent;
   margin-bottom: -1px;
   transition: color 0.3s ease, border-color 0.3s ease;
   text-decoration: none;
@@ -183,54 +183,62 @@ p.detail-description {
 
 .detail-nav-button:hover {
   color: var(--clr-primary);
+  border-bottom-color: var(--clr-primary);
 }
 
 .detail-nav-button.active {
   color: var(--clr-primary);
-  border-bottom-color: var(--clr-primary);
+  border-bottom: 3px solid var(--clr-primary);
 }
 
 .episode-list-container {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  border-radius: 10px;
+  background-color: var(--clr-bg-card);
+  border: 1px solid rgba(var(--clr-text-rgb), 0.1);
+  overflow: hidden;
 }
 
 .detail-episode-item {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0.8rem 1.2rem;
-  background-color: var(--clr-bg-card);
-  border: 1px solid rgba(var(--clr-text-rgb), 0.08);
+  padding: 1rem;
+  border-bottom: 1px solid rgba(var(--clr-text-rgb), 0.05);
   cursor: pointer;
   transition: background-color 0.2s ease, transform 0.2s ease,
     border-color 0.2s ease;
   text-decoration: none;
 }
 
+.detail-episode-item:last-child {
+  border-bottom: none;
+}
+
 body.dark .detail-episode-item {
-  background-color: rgba(var(--clr-primary-rgb), 0.05);
-  border-color: rgba(var(--clr-text-rgb), 0.1);
+  background-color: var(--clr-bg-card);
 }
 
 .detail-episode-item:hover {
-  background-color: rgba(var(--clr-primary-rgb), 0.1);
-  border-color: rgba(var(--clr-primary-rgb), 0.3);
+  background-color: rgba(var(--clr-primary-rgb), 0.1) !important;
+}
+
+.detail-episode-item:hover .episode-main-info {
   transform: translateX(5px);
 }
 
 .episode-main-info {
   display: flex;
   align-items: center;
-  gap: 0.8rem;
+  gap: 0.5rem;
   overflow: hidden;
   flex-grow: 1;
   margin-right: 0.5rem;
 }
 
 .detail-episode-number {
-  font-weight: 700;
+  font-weight: 600;
   color: var(--clr-primary);
 }
 
@@ -265,19 +273,19 @@ body.dark .detail-episode-item {
 }
 
 .player-series-title {
-  font-size: 1rem;
-  color: var(--clr-text-sub);
+  font-size: 1.2rem;
+  color: var(--clr-primary);
   text-decoration: none;
+  font-weight: 500;
 }
 
 .player-series-title:hover {
-  color: var(--clr-primary);
+  opacity: 0.7;
 }
 
 .player-episode-main-title {
   font-size: 1.8rem;
   font-weight: 700;
-  margin-top: 0.25rem;
 }
 
 .player-layout-grid {
@@ -337,17 +345,18 @@ body.dark .detail-episode-item {
 .player-sidebar {
   background: var(--clr-bg-card);
   border-radius: 14px;
-  padding: 1rem;
+  padding: .5rem;
   display: flex;
   flex-direction: column;
 }
 
 .sidebar-title {
-  font-size: 1.2rem;
   font-weight: 700;
-  margin-bottom: 1rem;
-  padding-bottom: 0.5rem;
+  padding: .5rem;
+  margin-bottom: .5rem;
   border-bottom: 1px solid rgba(var(--clr-text-rgb), 0.1);
+  font-size: 1.5rem;
+  padding-top: .25rem;
 }
 
 .player-episode-list-wrapper {
@@ -391,7 +400,6 @@ body.dark .detail-episode-item {
   overflow: hidden;
   text-overflow: ellipsis;
   flex-grow: 1;
-  margin-right: 0.5rem;
 }
 
 .player-episode-likes {
@@ -587,7 +595,7 @@ body.dark .detail-episode-item {
     justify-content: center;
   }
 
-  .episode-nav-button.list-button {
+  .episode-nav-button.last-button {
     display: none;
   }
 }
@@ -668,6 +676,7 @@ body.dark .detail-episode-item {
 
   .inline-song-info-mobile {
     display: flex;
+    flex-direction: column;
   }
 
   .inline-songs-container {
@@ -691,7 +700,7 @@ body.dark .detail-episode-item {
 
   .inline-song-info-mobile .inline-song-title {
     font-size: 0.75rem;
-    max-width: 120px;
+    max-width: 135px;
   }
 
   .detail-navigation-tabs {
@@ -706,7 +715,10 @@ body.dark .detail-episode-item {
 
   .detail-episode-item {
     padding: 0.7rem;
+    padding-left: .8rem;
     font-size: 0.8rem;
+    flex-direction: column;
+    align-items: flex-start;
   }
 
   .player-header {

--- a/css/pages/series-detail.css
+++ b/css/pages/series-detail.css
@@ -562,13 +562,18 @@ body.dark .detail-episode-item {
 
 @media (max-width: 992px) {
   .player-layout-grid {
-    grid-template-columns: 1fr;
+    display: flex;
+    flex-direction: column;
   }
 
   .player-sidebar {
-    grid-row: 2;
+    order: 2;
     margin-top: 1.5rem;
     max-height: 300px;
+  }
+
+  .player-main-content {
+    order: 1;
   }
 
   .episode-navigation {

--- a/css/pages/series-detail.css
+++ b/css/pages/series-detail.css
@@ -426,7 +426,8 @@ body.dark .detail-episode-item {
 
 .player-episode-item.active .player-episode-likes {
   cursor: default;
-  pointer-events: auto; /* Réactive les clics UNIQUEMENT sur cet élément */
+  pointer-events: auto;
+  /* Réactive les clics UNIQUEMENT sur cet élément */
 }
 
 .player-episode-item:not(.active) .player-episode-likes:hover {
@@ -663,7 +664,7 @@ body.dark .detail-episode-item {
     margin-top: 0.8rem;
   }
 
-  .series-detail-container > .detail-description {
+  .series-detail-container>.detail-description {
     display: block;
     font-size: 0.8rem;
     line-height: 1.5;
@@ -747,5 +748,15 @@ body.dark .detail-episode-item {
     width: auto;
     padding: 0.7rem 1rem;
     font-size: 0.7rem;
+  }
+
+  .detail-chapter-item .chapter-side-info,
+  .episode-side-info {
+    width: 100%;
+  }
+
+  .detail-episode-date {
+    font-size: 0.75rem;
+    margin-left: auto;
   }
 }

--- a/data/series/Kaoru_Hana_wa_Rin_to_Saku.json
+++ b/data/series/Kaoru_Hana_wa_Rin_to_Saku.json
@@ -1484,7 +1484,7 @@
       }
     },
     "140": {
-      "title": "Qu'est-ce que l'Amour _",
+      "title": "Qu'est-ce que l'Amour ?",
       "volume": "",
       "last_updated": "1740787200",
       "groups": {

--- a/functions/_middleware.js
+++ b/functions/_middleware.js
@@ -51,15 +51,6 @@ export async function onRequest(context) {
   }
   if (pathname === "/index") pathname = "/"; // Traite "index" comme racine
 
-  // Redirection legacy (si besoin)
-  if (pathname.startsWith("/series-detail")) {
-    const slugWithPotentialSubpaths = pathname.substring(
-      "/series-detail".length
-    );
-    const newUrl = new URL(slugWithPotentialSubpaths, url.origin);
-    return Response.redirect(newUrl.toString(), 301);
-  }
-
   // --- GESTION SPÉCIFIQUE DES URLS DE LA GALERIE ---
   if (pathname.startsWith("/galerie")) {
     const metaData = {

--- a/js/pages/series-detail/MangaReader/ui.js
+++ b/js/pages/series-detail/MangaReader/ui.js
@@ -314,10 +314,22 @@ export function renderViewer() {
         // Sous-cas 2b: C'est une page portrait seule (début/fin de chapitre). Elle a besoin d'un placeholder.
         else {
           const placeholder = document.createElement("div");
-          if (state.settings.direction === "rtl") {
-            viewer.append(placeholder, image);
+          if (state.currentSpreadIndex === 0) {
+            // Pour la première planche
+            if (state.settings.direction === "rtl") {
+              // En RTL, l'image va à gauche
+              viewer.append(image, placeholder);
+            } else {
+              // En LTR, l'image va à droite
+              viewer.append(placeholder, image);
+            }
           } else {
-            viewer.append(image, placeholder);
+            // Pour toutes les autres planches
+            if (state.settings.direction === "rtl") {
+              viewer.append(placeholder, image);
+            } else {
+              viewer.append(image, placeholder);
+            }
           }
         }
       }

--- a/js/pages/series-detail/animeView.js
+++ b/js/pages/series-detail/animeView.js
@@ -184,7 +184,7 @@ export async function renderEpisodesListView(seriesData, seriesSlug) {
       <div id="reading-actions-container"></div>
       ${navTabsHtml}
       <div id="chapters-list-section" class="episodes-main-header">
-          <h3 class="section-title">Liste des Épisodes</h3>
+          <h3 class="section-title">Liste des épisodes</h3>
       </div>
       <div class="episode-list-container">
           ${episodeListHtml}
@@ -252,7 +252,7 @@ export async function renderEpisodePlayerView(
       }" class="player-episode-item ${isActive}" data-episode-number="${
         ep.indice_ep
       }">
-          <span class="player-episode-number">Épisode ${ep.indice_ep}</span>
+          <span class="player-episode-number">Ép. ${ep.indice_ep}</span>
           <span class="player-episode-title">${
             ep.title_ep || "Titre inconnu"
           }</span>
@@ -320,7 +320,10 @@ export async function renderEpisodePlayerView(
             </div>
             <div class="episode-navigation">
                 ${prevButton}
-                <a href="/${seriesSlug}/episodes" class="episode-nav-button list-button"><i class="fas fa-list-ul"></i> Liste</a>
+                ${currentEpisode.indice_ep === chronoSortedEpisodes[chronoSortedEpisodes.length - 1].indice_ep 
+                  ? `<span class="episode-nav-button last-button disabled"><i class="fas fa-fast-forward"></i> Dernier</span>`
+                  : `<a href="/${seriesSlug}/episodes/${chronoSortedEpisodes[chronoSortedEpisodes.length - 1].indice_ep}" class="episode-nav-button last-button"><i class="fas fa-fast-forward"></i> Dernier</a>`
+                }
                 ${nextButton}
             </div>
           </div>

--- a/js/pages/series-detail/components.js
+++ b/js/pages/series-detail/components.js
@@ -2,7 +2,6 @@
 
 function renderInlineThemeSong(song, type) {
     if (!song) return '';
-    const typeShort = type === 'Opening' ? 'OP' : 'ED';
     const mobileTitle = song.title_op_fr_an || song.title_op_jp_an;
     const title_fr = song.title_op_fr_an || '';
     const title_jp = song.title_op_jp_an ? ` [${song.title_op_jp_an}]` : '';
@@ -17,7 +16,7 @@ function renderInlineThemeSong(song, type) {
               ${author}
           </div>
           <div class="inline-song-info-mobile">
-              <span class="inline-song-type">${typeShort}</span>
+              <span class="inline-song-type">${type}</span>
               <span class="inline-song-title">${mobileTitle}</span>
           </div>
         </a>

--- a/js/pages/series-detail/mangaView.js
+++ b/js/pages/series-detail/mangaView.js
@@ -60,12 +60,9 @@ function renderReadingActions(seriesData, seriesSlug) {
       nextChapter = chapters[lastReadIndex + 1];
     }
   }
-  const lastChapterUrl = `/${seriesSlug}/${String(lastChapter).replaceAll(
-    ".",
-    "-"
-  )}`;
+  const lastChapterUrl = `/${seriesSlug}/${String(lastChapter)}`;
   const nextChapterUrl = nextChapter
-    ? `/${seriesSlug}/${String(nextChapter).replaceAll(".", "-")}`
+    ? `/${seriesSlug}/${String(nextChapter)}`
     : null;
   let buttonsHtml = "";
   if (nextChapterUrl) {
@@ -148,7 +145,7 @@ function renderChaptersListForVolume(chaptersToRender, seriesSlug) {
       }</span>`;
 
       if (!isLicensed && c.groups && c.groups.Big_herooooo) {
-        href = `/${seriesSlug}/${String(c.chapter).replaceAll(".", "-")}`;
+        href = `/${seriesSlug}/${String(c.chapter)}`;
         if (c.groups.Big_herooooo.includes("/proxy/api/imgchest/chapter/")) {
           const parts = c.groups.Big_herooooo.split("/");
           const imgchestPostId = parts[parts.length - 1];

--- a/js/pages/series-detail/mangaView.js
+++ b/js/pages/series-detail/mangaView.js
@@ -139,8 +139,8 @@ function renderChaptersListForVolume(chaptersToRender, seriesSlug) {
 
       const likesHtml = `<span class="detail-chapter-likes ${
         localState.hasLiked ? "liked" : ""
-      }" title="J'aime"><i class="fas fa-heart"></i> ${displayLikes}</span>`;
-      const commentsHtml = `<span class="detail-chapter-comments" title="Commentaires"><i class="fas fa-comment"></i> ${
+        }" title="J'aime" data-like-count="${displayLikes}"><i class="fas fa-heart"></i> ${displayLikes}</span>`;
+      const commentsHtml = `<span class="detail-chapter-comments" title="Commentaires" data-comment-count="${serverStats.comments?.length || 0}"><i class="fas fa-comment"></i> ${
         serverStats.comments?.length || 0
       }</span>`;
 
@@ -231,16 +231,16 @@ function displayGroupedChapters(seriesData, seriesSlug) {
       const chaptersInVolume = grouped.get(volKey);
       const licenseDetails = volumeLicenseInfo.get(volKey);
       const isActiveByDefault = true;
-      let volumeHeaderContent = `<h4 class="volume-title-main">${volumeDisplayName}</h4>`;
+      let volumeHeaderContent = `<h4 class="volume-title-main">${volumeDisplayName}`;
       if (licenseDetails) {
-        volumeHeaderContent += `<div class="volume-license-details"><span class="volume-license-text">Disponible en papier, commandez-le</span><a href="${
-          licenseDetails[0]
-        }" target="_blank" rel="noopener noreferrer" class="volume-license-link">ici !</a>${
-          licenseDetails[1]
-            ? `<span class="volume-release-date">${licenseDetails[1]}</span>`
-            : ""
-        }</div>`;
+        volumeHeaderContent += `${licenseDetails[1]
+          ? ` <span class="volume-release-date">(${licenseDetails[1]})</span> `
+          : ""
+          }`
+        volumeHeaderContent += `<span class="volume-license-text">Disponible en papier, commandez-le <a href="${licenseDetails[0]
+          }" target="_blank" rel="noopener noreferrer" class="volume-license-link">ici !</a></span>`;
       }
+      volumeHeaderContent += "</h4>"
       return `<div class="volume-group"><div class="volume-header ${
         isActiveByDefault ? "active" : ""
       }" data-volume="${volKey}">${volumeHeaderContent}<i class="fas fa-chevron-down volume-arrow ${
@@ -274,7 +274,7 @@ export async function renderMangaView(seriesData, seriesSlug) {
   const container = qs("#series-detail-section");
   if (!container || !seriesData) return;
   const navTabsHtml = generateNavTabs(seriesData, seriesSlug, "manga");
-  const chaptersSectionHtml = `<div id="chapters-list-section" class="chapters-main-header"><h3 class="section-title">Liste des Chapitres</h3><div class="chapter-sort-filter"><button id="sort-volumes-btn" class="sort-button" title="Trier les volumes"><i class="fas fa-sort-numeric-down-alt"></i></button></div></div><div class="chapters-accordion-container"></div>`;
+  const chaptersSectionHtml = `<div id="chapters-list-section" class="chapters-main-header"><h3 class="section-title">Liste des chapitres</h3><div class="chapter-sort-filter"><button id="sort-volumes-btn" class="sort-button" title="Trier les volumes"><i class="fas fa-sort-numeric-down-alt"></i></button></div></div><div class="chapters-accordion-container"></div>`;
   container.innerHTML = `${generateSeriesHeader(
     seriesData
   )}<div id="reading-actions-container"></div>${navTabsHtml}${chaptersSectionHtml}`;


### PR DESCRIPTION
## contenu de cette pr

* fix pour les liens des chapitres "extras"/à virgule (comme `2.5`, `127.5`)
* ajout d'une page 404
* sinon que des styles

### chapitres extras

dans la liste des chapitres, si on clique sur un chapitre extra, il ne mène pas au chapitre car mauvaise url :

<img width="372" height="118" alt="image" src="https://github.com/user-attachments/assets/a1864176-231e-44d1-99a9-3a913eb5a7e1" />

l'url correcte est https://bigsolo.org/kaoru_hana_wa_rin_to_saku/2.5 (avec un point dans l'url) donc j'ai fix ça.

<img width="364" height="108" alt="image" src="https://github.com/user-attachments/assets/d23e8a20-639d-4f06-94d8-5e4c9225568c" />

### page 404

avant, si on tombait sur un lien cassé, il menait à la page d'accueil sans explication.

-> https://bigsolo.org/exemple:_ce_lien_ne_marche_pas

du coup, j'ai rajouté une page qui s'affichera si quelqu'un tombe sur un lien cassé.

<img width="1130" height="691" alt="image" src="https://github.com/user-attachments/assets/49405a53-5cf8-42ce-adb2-1373d361c6fb" />

### autres

* j'ai fix un titre de chapitre : (KH 140)
<img width="1622" height="62" alt="image" src="https://github.com/user-attachments/assets/bc94df11-0490-4f10-85ad-485fa4f45095" />

* j'ai remplacé la redirection `/series-detail/*` du middleware par un redirect cloudflare pages (`_redirects`); c'est censé être géré par cloudflare directement (voir [doca](https://developers.cloudflare.com/pages/configuration/redirects/)) et ça devrait être un chouïa plus rapide à répondre.
<img width="228" height="56" alt="image" src="https://github.com/user-attachments/assets/48f8dede-2f12-4fee-97c3-9f1c5749da8a" />

### styles ~ lecteur

* alignement de la première page à droite si mode RTL (droite à gauche) :
<img width="3378" height="1016" alt="Frame 12" src="https://github.com/user-attachments/assets/340af232-d2ef-4e13-b7ac-3e4352a01209" />

* j'ai également un peu rétréci les pages pour qu'elles ne soient pas coupées par la progress bar.

### styles ~ vue épisode

* fix vue épisode qui débordait sur petits écrans :

<img width="792" height="674" alt="image" src="https://github.com/user-attachments/assets/2f22960e-1c89-4391-8ad8-4e4977cea095" />

* petit changements de styles sur la sidebar (permet d'afficher les titres d'épisode en entier)
<img width="3378" height="1016" alt="Frame 11" src="https://github.com/user-attachments/assets/7cc1344a-a35c-495e-9a43-e65e0f07b747" />

* j'ai aussi retiré le bouton "Liste" car il portait à confusion (on a la liste des épisodes à gauche), et je l'ai remplacé par un bouton "Dernier épisode". les informations de l'anime sont toujours accessibles en appuyant sur le titre de l'anime en haut à gauche (j'ai un peu changé les styles pour le mettre en avant).

### styles ~ series-detail

* les animations sont maintenant ultra clean dans series-detail :o 
![Recording 2025-08-07 at 20 32 25](https://github.com/user-attachments/assets/90dd2bc9-4b57-46c3-b9b4-3b1f617f8eee)

* les épisodes ont maintenant le même style que les chapitres et les mêmes animations :
<img width="1692" height="1024" alt="image" src="https://github.com/user-attachments/assets/72e66550-71e5-40d7-9f96-dc258e2d0608" />

* sur mobile, j'ai séparé les informations des chapitres/épisodes en deux lignes : ça permet d'avoir plus de marge pour appuyer et ça permet également d'avoir les informations en entier.
<img width="954" height="882" alt="image" src="https://github.com/user-attachments/assets/bf4d0ecd-719d-4fb3-b72f-7920467ad6f9" />
<img width="954" height="882" alt="image" src="https://github.com/user-attachments/assets/50ab6aae-b592-4fe2-812b-91411dd7a884" />
<img width="826" height="706" alt="image" src="https://github.com/user-attachments/assets/f15fa7e4-9998-4c80-9d63-a4789a65bb02" />
