### PR TITLE
fix redirection des anciens liens chapitres & épisodes

### DIFF
--- a/functions/_middleware.js
+++ b/functions/_middleware.js
@@ -76,7 +76,7 @@ export async function onRequest(context) {
   if (seriesName.includes("_") && !knownPrefixes.includes(`/${seriesName}/`)) {
     const newSeriesName = slugify(seriesName);
     const pathname = originalPathname.replace(seriesName, newSeriesName);
-    const newUrl = new URL(newSeriesName, url.origin);
+    const newUrl = new URL(pathname, url.origin);
     newUrl.search = url.search;
     newUrl.hash = url.hash;
     console.log(


### PR DESCRIPTION
## contenu de la pr

pr très simple, règle la redirection qui redirigeait tous les anciens liens (que ce soit un chapitre ou un épisode) au `series-detail` manga.

https://bigsolo.org/kaoru_hana_wa_rin_to_saku/163
-> https://bigsolo.org/kaoru-hana-wa-rin-to-saku
au lieu de https://bigsolo.org/kaoru-hana-wa-rin-to-saku/163